### PR TITLE
fix: still show filters when no events found

### DIFF
--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -124,15 +124,6 @@ export default function EventList({ initialEvents }: Props) {
     setMode: setTipo,
   }
 
-  if (!loading && filteredEvents.length === 0) {
-    return (
-      <div className="min-h-screen bg-background">
-        <NoEvents />
-        <Footer />
-      </div>
-    )
-  }
-
   return (
     <div className="min-h-screen bg-background">
       {process.env.NODE_ENV === 'development' && <ScreenSizeButton />}
@@ -140,8 +131,9 @@ export default function EventList({ initialEvents }: Props) {
         <div className="mb-8 flex flex-col items-center gap-2 lg:gap-4">
           <div className="relative w-full">
             <div
-              className={`absolute right-0 top-0 transition-opacity duration-300 ${isScrolled ? 'pointer-events-none opacity-0' : 'opacity-100'
-                }`}
+              className={`absolute right-0 top-0 transition-opacity duration-300 ${
+                isScrolled ? 'pointer-events-none opacity-0' : 'opacity-100'
+              }`}
             >
               <ThemeToggle />
             </div>
@@ -213,6 +205,7 @@ export default function EventList({ initialEvents }: Props) {
               ))}
             </div>
           ))}
+        {!loading && filteredEvents.length === 0 && <NoEvents />}
       </div>
       <Footer />
     </div>


### PR DESCRIPTION
# Descrição

<!-- 
Inclua um resumo das alterações e qual problema foi corrigido. Inclua também motivação e/ou contextos relevantes. Liste todas as dependências necessárias para essa alteração.
-->

Essa alteração serve para manter a mesma estrutura do website quando não há nenhum evento. O principal agravante disso era que a barra de filtros sumia e eu só conseguia acessá-la de volta caso eu recarregasse a página.

Esse é o estado atual:

<img width="1674" height="997" alt="image" src="https://github.com/user-attachments/assets/52001130-462e-4169-988d-c674fd71604d" />

Fixes #14

## Tipo de mudança 🏗️

<!-- _Exclua as opções que não são relevantes._ -->

Minha mudança é uma:

- [x] Correção de bug (alteração que corrige um problema)

## Como isso foi testado? 🧪

<!-- Descreva os testes que você executou para verificar suas alterações.
Forneça instruções para que possamos reproduzir.
Liste também todos os detalhes relevantes para sua configuração de teste. -->

Em razão da maneira como o código foi pensado, quando não havia nenhum evento a mostrar, ele ignorava o restante do conteúdo em razão do early return.

Meu trabalho foi de mover a lógica de mostrar o componente `<NoEvents />` dentro dos mesmos componentes que são mostrados os eventos.

## Checklist da PR ✅

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma autoavaliação do meu próprio código
- [ ] Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos `warnings`
- [x] O título do meu PR está seguindo o padrão <type>(scope): subject.
  - Exemplo 1 (com escopo): feat(page): add collaborators page
  - Exemplo 2 (sem escopo): fix: prevent auto reload